### PR TITLE
Allow Underscore in Channel ID

### DIFF
--- a/app/src/main/java/me/singleneuron/locknotification/Fragment/AddConfigDetailFragment.kt
+++ b/app/src/main/java/me/singleneuron/locknotification/Fragment/AddConfigDetailFragment.kt
@@ -67,7 +67,7 @@ class AddConfigDetailFragment : PreferenceFragmentCompat() {
             if (value!=null) preference!!.summary = value.toString()
             preference!!.setOnPreferenceChangeListener { preference1, newValue ->
                 if (it.contains("Key",true)) {
-                    if (!Pattern.matches("^[a-z0-9A-Z]+$",newValue as String)) {
+                    if (!Pattern.matches("^[a-z0-9A-Z_]+$",newValue as String)) {
                         Toast.makeText(requireContext(),preference1.title.toString() + getString(R.string.only_letters_and_numbers),Toast.LENGTH_LONG).show()
                         return@setOnPreferenceChangeListener false
                     }


### PR DESCRIPTION
Currently, only characters and numbers are allowed for notification channel ID field. However, there appear to be plenty of notification channels with underscores in channel ID. Underscores should thus be allowed.